### PR TITLE
Add Snowflake Streamlit workflow example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
+# Streamlit Snowflake n8n App
 
+This project contains a minimal Streamlit application meant to run in
+Snowflake's Streamlit environment. The app lets you build a list of SQL
+steps and execute them sequentially with a simple UI inspired by `n8n`.
+
+## Running locally
+
+Install the required packages:
+
+```bash
+pip install streamlit snowflake-snowpark-python
+```
+
+Set your Snowflake credentials via environment variables:
+
+- `SNOWFLAKE_ACCOUNT`
+- `SNOWFLAKE_USER`
+- `SNOWFLAKE_PASSWORD`
+- `SNOWFLAKE_ROLE`
+- `SNOWFLAKE_WAREHOUSE`
+- `SNOWFLAKE_DATABASE`
+- `SNOWFLAKE_SCHEMA`
+
+Then start the app:
+
+```bash
+streamlit run app.py
+```
+
+The app will allow you to add SQL queries as workflow steps and run them
+in order against your Snowflake database.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,84 @@
+import os
+import streamlit as st
+from snowflake.snowpark import Session
+
+st.set_page_config(page_title="Snowflake n8n Workflow", page_icon=":snowflake:")
+st.title("Snowflake Streamlit App - n8n")
+
+st.markdown(
+    """
+    <style>
+        .node-box {
+            border: 1px solid #ddd;
+            border-radius: 6px;
+            padding: 0.5rem;
+            margin-bottom: 0.5rem;
+            background-color: #fafafa;
+            box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+        }
+        .node-title {
+            font-weight: 600;
+            color: #228b22;
+            margin-bottom: 0.25rem;
+        }
+        pre {
+            margin: 0;
+        }
+    </style>
+    """,
+    unsafe_allow_html=True,
+)
+
+# Helper to create a Snowflake session
+
+def create_session():
+    conn_params = {
+        "account": os.environ.get("SNOWFLAKE_ACCOUNT"),
+        "user": os.environ.get("SNOWFLAKE_USER"),
+        "password": os.environ.get("SNOWFLAKE_PASSWORD"),
+        "role": os.environ.get("SNOWFLAKE_ROLE"),
+        "warehouse": os.environ.get("SNOWFLAKE_WAREHOUSE"),
+        "database": os.environ.get("SNOWFLAKE_DATABASE"),
+        "schema": os.environ.get("SNOWFLAKE_SCHEMA"),
+    }
+    if not all(conn_params.values()):
+        missing = [k for k, v in conn_params.items() if not v]
+        st.warning(f"Missing connection parameters: {', '.join(missing)}")
+        return None
+    return Session.builder.configs(conn_params).create()
+
+# Initialize workflow steps in session state
+if "steps" not in st.session_state:
+    st.session_state.steps = []
+
+st.header("Add Workflow Step")
+with st.form("add_step"):
+    name = st.text_input("Step name")
+    query = st.text_area("SQL query")
+    submitted = st.form_submit_button("Add Step")
+
+if 'submitted' in locals() and submitted:
+    if query:
+        st.session_state.steps.append({"name": name or f"Step {len(st.session_state.steps)+1}", "query": query})
+        st.success("Step added")
+    else:
+        st.warning("Enter a query before adding")
+
+if st.session_state.steps:
+    st.subheader("Workflow")
+    for i, step in enumerate(st.session_state.steps, 1):
+        st.markdown(
+            f"<div class='node-box'><div class='node-title'>{i}. {step['name']}</div><pre>{step['query']}</pre></div>",
+            unsafe_allow_html=True,
+        )
+
+if st.button("Run Workflow"):
+    if not st.session_state.steps:
+        st.warning("No steps to run")
+    else:
+        session = create_session()
+        if session:
+            for i, step in enumerate(st.session_state.steps, 1):
+                st.write(f"Executing {step['name']} ({i})")
+                df = session.sql(step["query"]).to_pandas()
+                st.dataframe(df)


### PR DESCRIPTION
## Summary
- add a basic Streamlit app `app.py` that connects to Snowflake and executes a series of SQL steps
- document how to run the Streamlit app and configure credentials
- refine the app UI with a simple n8n-inspired design and allow naming workflow steps

## Testing
- `python3 -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_687b7ad8ba9483338c6c6357d7d55687